### PR TITLE
Add global loop toggle button

### DIFF
--- a/soundboard_meme/README.md
+++ b/soundboard_meme/README.md
@@ -2,6 +2,10 @@
 
 A new Flutter project.
 
+## Features
+
+- Global loop toggle button to repeat sounds continuously.
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.

--- a/soundboard_meme/lib/providers/sound_provider.dart
+++ b/soundboard_meme/lib/providers/sound_provider.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/sound.dart';
 
 class SoundProvider extends ChangeNotifier {
+  bool _isLooping = false;
   // Start with an empty list of sounds. Add your own
   // entries pointing to assets in `assets/sounds` and
   // `assets/images`.
@@ -33,6 +34,8 @@ class SoundProvider extends ChangeNotifier {
   }
 
   String get category => _category;
+
+  bool get isLooping => _isLooping;
 
   List<Sound> get sounds {
     var list = _sounds;
@@ -87,6 +90,11 @@ class SoundProvider extends ChangeNotifier {
 
   void setSearch(String query) {
     _searchQuery = query;
+    notifyListeners();
+  }
+
+  void toggleLooping() {
+    _isLooping = !_isLooping;
     notifyListeners();
   }
 }

--- a/soundboard_meme/lib/screens/home_page.dart
+++ b/soundboard_meme/lib/screens/home_page.dart
@@ -22,6 +22,14 @@ class _HomePageState extends State<HomePage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Meme Sound Board'),
+        actions: [
+          IconButton(
+            icon: Icon(
+              provider.isLooping ? Icons.repeat_on : Icons.repeat,
+            ),
+            onPressed: provider.toggleLooping,
+          ),
+        ],
         bottom: !isFavoritesPage
             ? PreferredSize(
                 preferredSize: const Size.fromHeight(80),
@@ -123,23 +131,33 @@ class SoundTile extends StatefulWidget {
 
 class _SoundTileState extends State<SoundTile> {
   late final AudioPlayer _player;
-  bool _isLooping = false;
+  late final SoundProvider _provider;
+
+  void _onProviderChanged() {
+    _player.setReleaseMode(
+      _provider.isLooping ? ReleaseMode.loop : ReleaseMode.stop,
+    );
+  }
 
   @override
   void initState() {
     super.initState();
     _player = AudioPlayer();
+    _provider = Provider.of<SoundProvider>(context, listen: false);
+    _provider.addListener(_onProviderChanged);
+    _onProviderChanged();
   }
 
   @override
   void dispose() {
+    _provider.removeListener(_onProviderChanged);
     _player.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final provider = Provider.of<SoundProvider>(context, listen: false);
+    final provider = _provider;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(16),
@@ -148,7 +166,8 @@ class _SoundTileState extends State<SoundTile> {
         splashColor: Colors.white24,
         onTap: () async {
           await _player.stop();
-          await _player.setReleaseMode(ReleaseMode.stop);
+          await _player.setReleaseMode(
+              provider.isLooping ? ReleaseMode.loop : ReleaseMode.stop);
           await _player.play(AssetSource(widget.sound.assetPath));
         },
         child: Ink(
@@ -190,27 +209,6 @@ class _SoundTileState extends State<SoundTile> {
                 ),
               ),
 
-              // Loop Icon at top left
-              Positioned(
-                top: 1,
-                left: 1,
-                child: IconButton(
-                  icon: Icon(
-                    _isLooping ? Icons.repeat_on : Icons.repeat,
-                    color: Colors.white,
-                  ),
-                  onPressed: () async {
-                    if (_isLooping) {
-                      await _player.stop();
-                      setState(() => _isLooping = false);
-                    } else {
-                      await _player.setReleaseMode(ReleaseMode.loop);
-                      await _player.play(AssetSource(widget.sound.assetPath));
-                      setState(() => _isLooping = true);
-                    }
-                  },
-                ),
-              ),
 
               // Favorite Icon at top right
               Positioned(


### PR DESCRIPTION
## Summary
- implement global loop toggle in provider
- add loop button to AppBar
- play sounds in loop when enabled
- update README with new feature
- fix toggling loop state to update active players

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6872193ad6108331bfc7c6f9574b0ae4